### PR TITLE
fix module not using the correct nixpkgs

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -23,12 +23,7 @@
     hm-ricing-mode = forAllSystems (system: self.packages.${system}.hm-ricing-mode);
     defaultPackage = forAllSystems (system: self.packages.${system}.hm-ricing-mode);
 
-    homeManagerModules.hm-ricing-mode = { pkgs, ... }:
-    {
-      imports = [
-        "${self}/module/hm-ricing-mode.nix"
-      ];
-    };
+    homeManagerModules.hm-ricing-mode = import ./module/hm-ricing-mode.nix self;
 
     };
 }

--- a/module/hm-ricing-mode.nix
+++ b/module/hm-ricing-mode.nix
@@ -1,10 +1,11 @@
-{ config, lib, pkgs, ... }:
+self: { config, pkgs, lib, ... }:
 
 let
   cfg = config.programs.hm-ricing-mode;
   iniFormat = pkgs.formats.json { };
 
- 	hm-ricing-mode = pkgs.callPackage ../package/package.nix { inherit pkgs lib; };
+  inherit (pkgs.stdenv.hostPlatform) system;
+  hm-ricing-mode = self.packages.${system}.hm-ricing-mode;
 
   mipmip = {
     name = "Pim Snel";


### PR DESCRIPTION
This PR fixes #3, if not using `inputs.nixpkgs.follows` in flake input declaration. This only changes the ref for package `hm-ricing-mode` to use the same as defined in flake's outputs. Even being good to update this `flake.lock`, this PR will made this module more stable even if there's no frequent commits.